### PR TITLE
disregard this because b3313 v1.0 has been released; og title is 'from b3313 wiki: official b3313 1.0/2.0 releases are cancelled'

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is also not a complete fix: there are plenty of stars left unchanged, and s
 The patch might also introduce new bugs...  
 Use at your own risk! (I hope I didn't break any red stars...)
 
-*If you want a complete experience, I highly recommend waiting for the official 1.0 / 2.0 release instead!*  
+*If you want a complete experience, I highly recommend playing the unofficial 1.0 release instead!*  
   
 #### Changes
 400+ Assigned star IDs


### PR DESCRIPTION
From what I've seen so far, on the B3313 wiki 1.0 release is officially cancelled. And B3313 2.0 is cancelled too and one ex-dev name was confirmed to be JoshTheBosh according to The Plexus Discord.

![image](https://github.com/Charles445/B3313StarIdPatch/assets/39206651/aa4c2349-d807-4e5d-8043-1ed40d9bb3fb)

Sources:
https://b3313.fandom.com/wiki/List_of_Versions#cite_note-:0-1
The Plexus Discord server, you can join them by watching the B3313 Unabandoned release trailer.